### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/apps/ask-andrew/script.js
+++ b/apps/ask-andrew/script.js
@@ -529,7 +529,11 @@ Guidelines:
                 </div>
                 <div class="message-content">
                     <p class="message-author" aria-label="From Andrew">Andrew</p>
-                    <div class="message-text" ${isTyping ? 'aria-live="polite" aria-busy="true"' : ''}>${isTyping ? '<span class="typing-indicator" aria-label="Andrew is typing">●●●</span>' : content}</div>
+                    <div class="message-text" ${isTyping ? 'aria-live="polite" aria-busy="true"' : ''}>
+                        ${isTyping 
+                            ? '<span class="typing-indicator" aria-label="Andrew is typing">●●●</span>' 
+                            : this.escapeHtml(content)}
+                    </div>
                 </div>
             `;
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/GraemeMalcolm/ai-labs/security/code-scanning/1](https://github.com/GraemeMalcolm/ai-labs/security/code-scanning/1)

To safely render user-supplied or derivative content in the DOM, all potentially untrusted text should be robustly escaped before being used as HTML, especially in `.innerHTML`. The fix involves applying a strong HTML-escaping function (such as `this.escapeHtml`) to any value that came from the user input before interpolating it inside a template literal destined for `.innerHTML`.  
- Specifically, in `addMessage`, inside the assistant logic (`role === 'assistant'`), escape the variable `content` before using it in the `message-text` div (line 532).
- The conditional use for typing indicators is safe, but when not typing, `content` must be escaped.
- We do not need to change anything for the greeting, since it uses `formatResponse`, but should ensure escaping upstream.
- If `content` is already meant to contain rich text, a more granular sanitization approach may be needed, but given this context, robust escaping is the best fix.
- You may use the already defined `this.escapeHtml` function.
- Only change the code within apps/ask-andrew/script.js, specifically the affected block within `addMessage`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
